### PR TITLE
Create logical progression from Letter Shop to http-ilp tutorial

### DIFF
--- a/http-ilp/client1.js
+++ b/http-ilp/client1.js
@@ -1,0 +1,60 @@
+const IlpPacket = require('ilp-packet')
+const plugin = require('./plugins.js').xrp.Customer()
+const uuid = require('uuid/v4')
+const fetch = require('node-fetch')
+const crypto = require('crypto')
+
+function base64url (buf) {
+  return buf.toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function sha256 (preimage) {
+  return crypto.createHash('sha256').update(preimage).digest()
+}
+
+function hmac (secret, input) {
+  return crypto.createHmac('sha256', secret).update(input).digest()
+}
+
+plugin.connect().then(function () {
+  return fetch('http://localhost:8000/')
+}).then(function (res) {
+  const parts = res.headers.get('Pay').split(' ')
+  if (parts[0] === 'interledger-psk') {
+    const paymentId = 0
+    const destinationAmount = parts[1]
+    const destinationAddress = parts[2] + '.' + paymentId
+    const sharedSecret = Buffer.from(parts[3], 'base64')
+    const ilpPacket = IlpPacket.serializeIlpPayment({
+      account: destinationAddress,
+      amount: destinationAmount,
+      data: ''
+    })
+    console.log('Calculating hmac using shared secret:', base64url(sharedSecret))
+    const fulfillmentGenerator = hmac(sharedSecret, 'ilp_psk_condition')
+    const fulfillment =  hmac(fulfillmentGenerator, ilpPacket)
+    const condition = sha256(fulfillment)
+    return plugin.sendTransfer({
+      id: uuid(),
+      from: plugin.getAccount(),
+      to: destinationAddress,
+      ledger: plugin.getInfo().prefix,
+      expiresAt: new Date(new Date().getTime() + 1000000).toISOString(),
+      amount: destinationAmount,
+      executionCondition: base64url(condition),
+      ilp: base64url(ilpPacket)
+    })
+  }
+})
+
+plugin.on('outgoing_fulfill', function (transferId, fulfillmentBase64) {
+  fetch('http://localhost:8000/' + fulfillmentBase64).then(function (res) {
+    return res.text()
+  }).then(function (body) {
+    console.log(body)
+    return plugin.disconnect()
+  }).then(function () {
+    process.exit()
+  })
+})

--- a/http-ilp/client2.js
+++ b/http-ilp/client2.js
@@ -1,0 +1,70 @@
+const IlpPacket = require('ilp-packet')
+const plugin = require('./plugins.js').xrp.Customer()
+const uuid = require('uuid/v4')
+const fetch = require('node-fetch')
+const crypto = require('crypto')
+
+function base64url (buf) {
+  return buf.toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function sha256 (preimage) {
+  return crypto.createHash('sha256').update(preimage).digest()
+}
+
+function hmac (secret, input) {
+  return crypto.createHmac('sha256', secret).update(input).digest()
+}
+
+const sharedSecret = crypto.randomBytes(32)
+
+plugin.connect().then(function () {
+  return fetch('http://localhost:8000/', {
+    headers: {
+      'Pay-Token': base64url(sharedSecret)
+    }
+  })
+}).then(function (res) {
+  const parts = res.headers.get('Pay').split(' ')
+  if (parts[0] === 'interledger-psk') {
+    const paymentId = 0
+    const destinationAmount = parts[1]
+    const destinationAddress = parts[2] + '.' + paymentId
+    const sharedSecret = Buffer.from(parts[3], 'base64')
+    const ilpPacket = IlpPacket.serializeIlpPayment({
+      account: destinationAddress,
+      amount: destinationAmount,
+      data: ''
+    })
+    console.log('Calculating hmac using shared secret:', base64url(sharedSecret))
+    const fulfillmentGenerator = hmac(sharedSecret, 'ilp_psk_condition')
+    const fulfillment =  hmac(fulfillmentGenerator, ilpPacket)
+    const condition = sha256(fulfillment)
+    return plugin.sendTransfer({
+      id: uuid(),
+      from: plugin.getAccount(),
+      to: destinationAddress,
+      ledger: plugin.getInfo().prefix,
+      expiresAt: new Date(new Date().getTime() + 1000000).toISOString(),
+      amount: destinationAmount,
+      executionCondition: base64url(condition),
+      ilp: base64url(ilpPacket)
+    })
+  }
+})
+
+plugin.on('outgoing_fulfill', function (transferId, fulfillmentBase64) {
+  fetch('http://localhost:8000/', {
+    headers: {
+      'Pay-Token': base64url(sharedSecret)
+    }
+  }).then(function (res) {
+    return res.text()
+  }).then(function (body) {
+    console.log(body)
+    return plugin.disconnect()
+  }).then(function () {
+    process.exit()
+  })
+})

--- a/http-ilp/client3.js
+++ b/http-ilp/client3.js
@@ -1,0 +1,73 @@
+const IlpPacket = require('ilp-packet')
+const plugin = require('./plugins.js').xrp.Customer()
+const uuid = require('uuid/v4')
+const fetch = require('node-fetch')
+const crypto = require('crypto')
+
+function base64url (buf) {
+  return buf.toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function sha256 (preimage) {
+  return crypto.createHash('sha256').update(preimage).digest()
+}
+
+function hmac (secret, input) {
+  return crypto.createHmac('sha256', secret).update(input).digest()
+}
+
+// work around https://github.com/interledgerjs/ilp-plugin/pull/1
+plugin._prefix = 'g.crypto.ripple.escrow.'
+
+const sharedSecret = crypto.randomBytes(32)
+
+plugin.connect().then(function () {
+  return fetch('http://localhost:8000/', {
+    headers: {
+      'Pay-Token': base64url(sharedSecret)
+    }
+  })
+}).then(function (res) {
+  const parts = res.headers.get('Pay').split(' ')
+  if (parts.length === 3) {
+    const paymentId = 0
+    const destinationAmount = parts[0]
+    const destinationAddress = parts[1] + '.' + paymentId
+    const sharedSecret = Buffer.from(parts[2], 'base64')
+    const ilpPacket = IlpPacket.serializeIlpPayment({
+      account: destinationAddress,
+      amount: destinationAmount,
+      data: ''
+    })
+    console.log('Calculating hmac using shared secret:', base64url(sharedSecret))
+    const fulfillmentGenerator = hmac(sharedSecret, 'ilp_psk_condition')
+    const fulfillment =  hmac(fulfillmentGenerator, ilpPacket)
+    const condition = sha256(fulfillment)
+    return plugin.sendTransfer({
+      id: uuid(),
+      from: plugin.getAccount(),
+      to: destinationAddress,
+      ledger: plugin.getInfo().prefix,
+      expiresAt: new Date(new Date().getTime() + 1000000).toISOString(),
+      amount: destinationAmount,
+      executionCondition: base64url(condition),
+      ilp: base64url(ilpPacket)
+    })
+  }
+})
+
+plugin.on('outgoing_fulfill', function (transferId, fulfillmentBase64) {
+  fetch('http://localhost:8000/', {
+    headers: {
+      'Pay-Token': base64url(sharedSecret)
+    }
+  }).then(function (res) {
+    return res.text()
+  }).then(function (body) {
+    console.log(body)
+    return plugin.disconnect()
+  }).then(function () {
+    process.exit()
+  })
+})

--- a/http-ilp/index.md
+++ b/http-ilp/index.md
@@ -2,38 +2,182 @@
 
 ## What you need before you start:
 
-* complete the [Letter Shop](./letter-shop) tutorial first
+* complete the [Letter Shop](./letter-shop) tutorial first, including the Bonus Step
 
 ## What you'll learn:
 
-* rewriting the letter shop with Koa ILP
-* how HTTP-ILP works
-* how to use ILP curl to make paid API requests
+* how to use the Pre-Shared Key (PSK) protocol for repeated conditional Interledger payments
+* how to use the ILP curl tool to automatically administer your plugin credentials
+* how to use the koa-ilp module in a webserver middleware framework
+* how to use a `Pay-Token` to pay for multiple http requests with prepaid balance
+
+## PSK
+
+The `Pay` header we used in the Letter Shop tutorial specifies which sha256 condition to
+use for the payment. But once this condition has been used, and its fulfillment (the
+preimage of the sha256 hash) has been made public, it cannot be reused.
+
+Therefore, if the Letter Shop wants to give its customers a way to securely pay for
+multiple letters, it can use the [Pre-Shared Secet (PSK)](https://interledger.org/rfcs/0016-pre-shared-key/draft-3.html)
+protocol, to give each customer
+a unique pre-shared secret, from which endless fulfillment/condition pairs can be derived.
+
+To do this, the shop needs to use a `Pay` header with the 'interledger-psk' payment method, instead
+of the 'interledger-condition' method which we used in the previous tutorial.
+
+In order to make each client uniquely identifiable, a different `clientId` is added to the shop's
+ILP address. This means each client will pay the shop at a different ILP address,
+but these payments still all arrive at the shop. The client will then add another identifier
+to the end of the destination address, to make each of its multiple payments unique. So the ILP
+address of the shop is then made up of `<ledger prefix> . < accountId > . < clientId > . < paymentId >`.
+
+Apart from the payment's destination address, the client will also use the payment's amount
+(measured at the destination), and optional
+extra data to derive a fulfillment/condition pair from. The amount is expressed as an big-endian unsigned 64-bit
+integer. The three bits of data (address, amount, data), are OER-encoded in a specific, deterministic way,
+to get a binary string over which we can calculate an hmac. In the client, this process looks as follows:
+
+```js
+const paymentId = 0
+const destinationAmount = parts[1]
+const destinationAddress = parts[2] + '.' + paymentId
+const sharedSecret = Buffer.from(parts[3], 'base64')
+const ilpPacket = IlpPacket.serializeIlpPayment({
+  account: destinationAddress,
+  amount: destinationAmount,
+  data: ''
+})
+console.log('Calculating hmac using shared secret:', base64url(sharedSecret))
+const fulfillmentGenerator = hmac(sharedSecret, 'ilp_psk_condition')
+const fulfillment =  hmac(fulfillmentGenerator, ilpPacket)
+const condition = sha256(fulfillment)
+```
+
+The `ilpPacket` is the OER-encoded binary string from which the fulfillment/condition pair is derived.
+This process is deterministic, in the sense that if the client sends the ILP packet along with the
+payment (which it does), that will allow the shop to see the client's `clientId`, and to derive the
+same fulfillment/condition pair as the client did.
+
+The `paymentId` is still always set to 0 in this tutorial, so we're not really making use of PSK's ability
+to derive endless fulfillment/condition pairs from a single shared secret; we're mainly using PSK here because
+'interledger-psk' is a more standard payment method than 'interledger-condition', and more tools are available
+for it, as we'll see shortly.
+
+Later, in the [Streaming Payments](../streaming-payments) tutorial, we will also see how to use multiple payments
+from a single PSK secret to get multiple letters.
+
+Now copy your `plugins.js` file from the Letter Shop tutorial, and then run `node ./shop1.js` in one terminal
+screen, and `node ./client1.js` in another, to see this in action!
+
+## Using the `Pay-Token` and `Pay-Balance` headers
+
+The use of PSK in the `Pay` header is a great step forward in our Letter Shop design, because it makes doing multiple
+payments to the same shop easier. But we can also make an optimization in the opposite direction: what if you could
+pay more than the invoice amount, to obtain a prepaid balance at the shop? If the ledger(s) over which your payment
+travels are slow or expensive to use (*cough* bitcoin *cough*), and you know you will probably need to buy more letters
+in the future, it could make sense to pay extra, and obtain a balance at the shop, represented by a token.
+
+To implement this, we first need to decouple the retrieval of the letter from the fulfillment of the payment. So
+instead of sending the fulfillment as proof of payment, the client will send its shared secret to prove that they are
+the client that has a certain prepaid balance at the shop. And as we change this, at the same time, we'll move it
+from the URL path (where the client was putting the base64url-encoded fulfillment), to an http request header, which
+we'll call `Pay-Token`. The shop will also add a response header, `Pay-Balance`, which will inform the client of its
+current balance.
+
+Note that in the [Trustlines](../trustlines) tutorial, we will see another way of implementing the idea of prepaid
+balance at the shop; there, the shop will run an Interledger-enabled ledger, at which the client has a balance. Both
+have advantages and disadvantages, as will be discussed in more detail in the trustlines tutorial.
+
+
+## Customer-generated shared secret
+
+A final optimization we want to make is to allow the client to pick its own shared secret, instead of getting one
+assigned by the shop. This can be useful when, for instance, a user has two devices (one for paying, one for consuming),
+and these devices are not connected to each other, but they do have a shared secret between them (for instance, the same
+ssh key is installed on both devices). The user can then use one device to put prepaid credit "on" that shared secret at
+the shop, and use the other devices to consume the letter. Implementing this is quite simple: the client already sends
+a `Pay-Token` header on its first request:
+
+```js
+const sharedSecret = crypto.randomBytes(32)
+
+plugin.connect().then(function () {
+  return fetch('http://localhost:8000/', {
+    headers: {
+      'Pay-Token': base64url(sharedSecret)
+    }
+  })
+```
+
+And then instead of generating a shared secret for it, the shop will use that secret
+which the client picked.
+
+```js
+     const sharedSecret = crypto.randomBytes(32)
+
+      // Use client-generated shared secret, if presented:
+      if (req.headers['Pay-Token']) {
+        sharedSecret = Buffer.from(req.headers['Pay-Token'], 'base64')
+        console.log('Accepted shared secret from client', req.headers['Pay-Token'])
+      }
+
+      // Store the shared secret to use when we get paid
+```
+
+You can see the changes from this and the previous section implemented in `shop2.js` and `client2.js`.
+
+# ILP Curl
+
+So far, in this tutorial, we updated the Letter Shop with three extra improvements:
+* use the (repeatable) `'interledger-psk'` payment method instead of the more basic `'interledger-condition'` method
+* add prepaid balance for each customer of the shop
+* let the client pick the shared secret
+
+As a reader, you may be asking yourself where all of these small improvements are going, and why we thought it's so important
+to add them in this tutorial. The answer is we didn't pick them by accident: they are all things you need to change
+to become compatible with the new 'http-ilp' standard. There are two final changes which we need to make in order to become
+compatible with the current experimental implementation of http-ilp (which is slightly different from the latest version of
+the http-ilp specification at IETF discussions): remove the `'interledger-psk '` string from the `Pay` header,
+and use a [different string](https://github.com/interledgerjs/ilp-plugin/pull/1) to identify the XRP testnet ledger 
+
+These last tweaks have been made in `shop3.js` and `client3.js`, and again,
+you can try running them to check that it works as expected.
+ 
+And now, finally, to prove that our shop is now compatible with other publically available http-ilp tools, run `shop3.js` and then
+instead of running `client3.js`, use the ilp-curl tool to buy a letter from the shop:
+
+```
+$ npm install -g ilp-curl
+$ ilp-curl -X GET localhost:8000
+Your letter: A
+```
+
+Behind the scenes, ilp-curl does the following:
+* get an account on the XRP testnet and save the credentials in your `~/.ilprc.json` if you don't have that file yet
+* read your plugin credentials from your `~/.ilprc.json` file (this file replaces `./plugins.js`)
+* generate a shared secret for http://localhost:8000
+* make an OPTIONS request to http://localhost:8000 to send the shared secret to the shop and learn the price of one letter
+* use an Interledger payment to deposit money into the prepaid account at the shop
+* retrieve one letter
+* print the result
 
 ## Koa ILP
 
-We'll change the Letter Shop from the previous tutorial a bit, to `shop2.js`. Instead of
-using a human-readable "Payment Required" message that starts with "Please ...", we will
-now use a machine-readable http header, and a fulfillment/condition pair that is generated
-deterministically from a secret that's shared between the shop and the client.
+Another cool module we want to show you, is koa-ilp. It allows you to rewrite the Letter Shop
+so that instead of the built-in `http` library, it will use the more powerful `koa`, which
+is a webserver middleware framework which is very popular among frontend developers.
 
-It turns out that this is a common use case for ILP, so there are already libraries that
-let us do this in node. We're going to be switching from the built-in `http` library to
-the more powerful `koa`. With Koa, we can simply import a module to make our server charge
-money for requests. We'll look further into how this works later.
+With Koa, we can simply import a module to make our server charge
+money for requests. As you can see, `shop-koa.js` is only a few lines:
 
 ```js
+const plugin = require('./plugins.js').xrp.Shop()
 const Koa = require('koa')
 const app = new Koa()
 const router = require('koa-router')()
 
-// instantiate our plugin just the same as before
-const Plugin = require('ilp-plugin-xrp-escrow')
-const plugin = new Plugin({
-  secret: 'ssGjGT4sz4rp2xahcDj87P71rTYXo',
-  account: 'rrhnXcox5bEmZfJCHzPxajUtwdt772zrCW',
-  server: 'wss://s.altnet.rippletest.net:51233'
-})
+// work around https://github.com/interledgerjs/ilp-plugin/pull/1
+plugin._prefix = 'g.crypto.ripple.escrow.'
 
 // We use the plugin to create a new koa middleware.  This allows us to add a
 // function to any endpoint that we want to ILP enable.
@@ -46,7 +190,7 @@ const ilp = new KoaIlp({ plugin })
 router.get('/', ilp.paid({ price: 1000 }), async ctx => {
   const letter = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ').split('')[(Math.floor(Math.random() * 26))]
   console.log('Sending letter:', letter)
-  ctx.body = { letter }
+  ctx.body = 'Your letter: ' + letter
 })
 
 // Add the route we defined to the application and then listen on port 8000.
@@ -59,22 +203,13 @@ app
 Start the new server with:
 
 ```sh
-$ DEBUG=* node shop2.js
+$ DEBUG=* node shop-koa.js
 ```
 
 ## Testing our Server
 
-Now we've got our server, but we still need a client. First let's just see what happens when
-we make a request to our server with `curl`.
-
-```sh
-$ curl -X GET localhost:8000/
-No valid payment token provided
-```
-
-HTTP ILP works by associating a balance with a 32-byte authentication token. We
-haven't given the server anything, so it doesn't know who to charge. Let's fix
-that by giving it a token:
+To give you more of a feel of what is happening between client and shop on the http level,
+let's just see what happens when we make a request to our server with `curl`.
 
 ```sh
 $ curl -X GET localhost:8000/ -H Pay-Token:BPtQLNWS7owdlvFlNkMKbVjpBlmvuh1A-V47XdYmeW8
@@ -84,8 +219,6 @@ Your Payment Token BPtQLNWS7owdlvFlNkMKbVjpBlmvuh1A-V47XdYmeW8 has no funds avai
 Oh, that's right. We haven't sent any money. We can see the human-readable
 message that the server gave back to us, but there's also a machine readable
 version that the ILP tools can use, specified in [HTTP-ILP](https://github.com/interledger/rfcs/blob/58d8dcb015b160a381313126fa3065c64406db05/0014-http-ilp/0014-http-ilp.md#http-ilp).
-
-## HTTP-ILP and The Pay Header
 
 Let's look at all the headers that came back on the request we just sent.
 We can do that by adding the verbose (`-v`) flag to curl.
@@ -123,38 +256,13 @@ They're called `Pay` and `Pay-Balance`.
 Pay: 1000 g.crypto.ripple.escrow.rrhnXcox5bEmZfJCHzPxajUtwdt772zrCW.JCOtNQAm8OQlKPHR8dMeJixwfDXdpEQJw BEYMjoXSFQSCKlFRZ6itCQ
 ```
 
-`Pay` is made up of three portions: There's an amount required to fund this
-request, an ILP address to send money to, and a shared secret. The shared
-secret lets us use the [PSK
-Protocol](https://github.com/interledger/rfcs/blob/master/0016-pre-shared-key/0016-pre-shared-key.md#pre-shared-key-transport-protocol-psk)
-to agree on a condition without communicating.  From this one shared secret, we
-can send as many payments as we want.
+As you can see, the `Pay` header is made up of three portions instead of four now (the payment method identifier `'interledger-psk'` at the beginning is omitted).
 
 The `Pay-Balance` header tells us how much money is on our token right now.
 We've not funded it yet, so the amount is `0`.
 
-# ILP Curl
-
-We want to make an HTTP request that includes payment, but our client from
-before won't work against the official HTTP ILP spec. Fortunately, there exists
-a tool for this purpose called ILP Curl.
-
-```
-$ npm install -g ilp-curl
-$ ilp-curl -X GET localhost:8000
-{ letter: 'A' }
-```
-
-We no longer have to specify a token; ILP curl will do that for us.
-Furthermore, it will acquire us some testnet XRP to fund its request.
-
-ILP curl makes a preliminary request which returns a 402. It takes out the
-`Pay` header and sends an ILP payment to the server, using XRP. Then, once the
-ILP payment has completed, it makes the request again and is successful.
-
 ## What you learned
 
-We learned how to use the high-level ILP developer tools to make a server that
-accepts payments.  We learned how HTTP-ILP uses the `Pay` header to tell
-clients how to automatically pay it.  Finally, we learned how to pay one of
-these servers with ILP Curl.
+We learned how to make our Letter Shop compatible with different versions of the newly proposed HTTP-ILP standard.
+We learned how to buy a letter with ILP Curl.
+Finally, we learned how to use the high-level ILP developer tools to rewrite our Letter Shop using the Koa webserver middleware framework.

--- a/http-ilp/shop-koa.js
+++ b/http-ilp/shop-koa.js
@@ -1,0 +1,27 @@
+const plugin = require('./plugins.js').xrp.Shop()
+const Koa = require('koa')
+const app = new Koa()
+const router = require('koa-router')()
+
+// work around https://github.com/interledgerjs/ilp-plugin/pull/1
+plugin._prefix = 'g.crypto.ripple.escrow.'
+
+// We use the plugin to create a new koa middleware.  This allows us to add a
+// function to any endpoint that we want to ILP enable.
+const KoaIlp = require('koa-ilp')
+const ilp = new KoaIlp({ plugin })
+
+// On the server's root endpoint, we add this ilp.paid() function, which
+// requires payment of 1000 XRP drops (0.001 XRP) in order to run the main
+// function code
+router.get('/', ilp.paid({ price: 1000 }), async ctx => {
+  const letter = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ').split('')[(Math.floor(Math.random() * 26))]
+  console.log('Sending letter:', letter)
+  ctx.body = 'Your letter: ' + letter
+})
+
+// Add the route we defined to the application and then listen on port 8000.
+app
+  .use(router.routes())
+  .use(router.allowedMethods())
+  .listen(8000)

--- a/http-ilp/shop3.js
+++ b/http-ilp/shop3.js
@@ -23,6 +23,9 @@ let balances = {}
 
 const cost = 10
 
+// work around https://github.com/interledgerjs/ilp-plugin/pull/1
+plugin._prefix = 'g.crypto.ripple.escrow.'
+
 console.log(`== Starting the shop server == `)
 console.log(` 1. Connecting to an account to accept payments...`)
 
@@ -90,7 +93,8 @@ console.log('request headers', req.headers)
 
       // Respond with a 402 HTTP Status Code (Payment Required)
       res.statusCode = 402
-      res.setHeader(`Pay`, `interledger-psk ${cost} ${account}.${clientId} ${base64url(sharedSecret)}`)
+      // res.setHeader(`Pay`, `interledger-psk ${cost} ${account}.${clientId} ${base64url(sharedSecret)}`)
+      res.setHeader(`Pay`, `${cost} ${account}.${clientId} ${base64url(sharedSecret)}`)
       res.setHeader(`Pay-Balance`, balances[base64url(sharedSecret)].toString())
 
       res.end(`Please send an Interledger-PSK payment of` +


### PR DESCRIPTION
By making the Letter Shop Bonus a 'client' script instead of a proxy, it fits better before the http-ilp, streaming-payments, and trustlines tutorials, which all follow that same setup (shop + client).

In the Letter Shop, the client script is first introduced as a script that parses the html page, to make it clearly felt by the reader that a machine-readable `Pay` header is useful. It then introduces the very simple `'interledger-condition'` payment method.

The http-ilp tutorial then first stays with the approach of showing what's going on, explaining how interledger-psk is better for repeated use, and how we can add a prepaid balance.

Then it replaces exploits the fact that we're now within the http-ilp standard, to replace the client script with ilp-curl, a handy debug tool which manages your plugin credentials.

And the last step is to show how the Letter Shop could be written within a webserver middleware framework like koa.