### PR TITLE
Update package.json

### DIFF
--- a/letter-shop/package.json
+++ b/letter-shop/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ilp-packet": "^1.3.0",
     "ilp-plugin-payment-channel-framework": "github:interledgerjs/ilp-plugin-payment-channel-framework#bs-clp",
-    "ilp-plugin-xrp-escrow": "github:michielbdejong/ilp-plugin-xrp-escrow#72e4178",
+    "ilp-plugin-xrp-escrow": "^1.0.5",
     "jsonlint": "^1.6.2",
     "node-fetch": "^1.7.3",
     "uuid": "^3.1.0"


### PR DESCRIPTION
An error was being thrown when i do an npm install. It seems this package in package.json does not exist "ilp-plugin-xrp-escrow": "github:michielbdejong/ilp-plugin-xrp-escrow#72e4178". I commented it out and added "ilp-plugin-xrp-escrow": "^1.0.5", and npm install was successful. 